### PR TITLE
#ログアウトページのビューファイル修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,4 +14,5 @@
 @import "modules/_new_user_registration";
 @import "modules/_new_user_session";
 @import "modules/_signup_account";
-@import "modules/_mypage"
+@import "modules/_mypage";
+@import "modules/_logout_confirmation"

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,4 +15,4 @@
 @import "modules/_new_user_session";
 @import "modules/_signup_account";
 @import "modules/_mypage";
-@import "modules/_logout_confirmation"
+@import "modules/_logout_confirmation";

--- a/app/assets/stylesheets/modules/_logout_confirmation.scss
+++ b/app/assets/stylesheets/modules/_logout_confirmation.scss
@@ -1,0 +1,24 @@
+.logout--container{
+  width:700px;
+  height:200px;
+  background-color: $white;
+  display:inline-block;
+}
+.logout--form_tag{
+  padding:64px;
+}
+.logout--content{
+  max-width: 320px;
+  margin:0 auto;
+}
+.logout--button{
+background-color: $mercari_red;
+text-align: center;
+height:50px;
+line-height: 50px;
+text-decoration: none;
+}
+.logout--button--text{
+  text-decoration: none;
+  color:$white;
+}

--- a/app/assets/stylesheets/modules/_user.scss
+++ b/app/assets/stylesheets/modules/_user.scss
@@ -24,6 +24,8 @@
             font-size: 14px;
             width: 100%;
             position: relative;
+            text-decoration: none;
+            color:$black;
             .icon{
               font-size: 14px;
               position: absolute;

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -96,6 +96,6 @@
           電話番号の確認
           = fa_icon 'chevron-right', class: 'icon'
       %li
-        %a.mypage--nav-list--item
+        %a.mypage--nav-list--item{href: "../users/logout_confirmation"}
           ログアウト
           = fa_icon 'chevron-right', class: 'icon'

--- a/app/views/users/logout_confirmation.html.haml
+++ b/app/views/users/logout_confirmation.html.haml
@@ -1,5 +1,10 @@
-.logout--container
-  .logout--form_tag
-    .logout--content
-      .logout--button
-        ログアウト
+= render 'layouts/header_form'
+.main-user-page
+  .user_container
+    =render "layouts/sidebar"
+    .logout--container
+      .logout--form_tag
+        .logout--content
+          .logout--button
+            = link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'logout--button--text'
+= render 'layouts/footer'


### PR DESCRIPTION
WHAT
ユーザーログアウトページのビューファイル修正
%a.mypage--nav-list--item{href: "../users/logout_confirmation"}
ログアウト
・マイページ サイドバー内のログアウトをクリックすると、ログアウトページに遷移する。

.logout--button
= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'logout--button--text'
link_toメソッドに,destroy_user_session_pathパスを設定。
ログアウトボタンをクリックするとユーザーのログアウトが実行される。

＃WHY
ユーザーのログアウト機能は必須であるため。