### PR TITLE
#商品一覧ページのリンク先追加、及び表示内容の微修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,7 @@ class ItemsController < ApplicationController
   def index
 
     @categories = Category.where(ancestry: nil)
-    @items = Item.order("created_at DESC")
+    @items = Item.order("created_at DESC").limit(4)
 
   end
 
@@ -31,6 +31,10 @@ class ItemsController < ApplicationController
 
   def search
     @items = Item.where('name LIKE?', "%#{params[:search]}%")
+  end
+
+  def user_buy_screen
+    @item = Item.find(params[:id])
   end
 
 private

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -22,7 +22,7 @@
     .items-box-content
       - @items.each do |item|
         .items-box
-          %a{href:''}
+          %a{ href: "/items/#{item.id}/user_buy_screen" }
             %figure.items-box-photo
               = image_tag item.image.url
             / %img{src:'item.image'}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   resources :items do
     member do
       get :confirm
+      get :user_buy_screen
     end
     collection do
       get :search


### PR DESCRIPTION
#WHAT

・商品一覧ページ（トップページ）にて、表示されている商品をクリックすると、商品詳細ページに遷移するようリンクを設定。
%a{ href: "/items/#{item.id}/user_buy_screen" }
商品詳細ページのビューファイルはuser_buy_screem.html.hamlという名前。

・トップページに商品が4つまで表示されるようにする。（一番左から、出品された時間が新しい順に表示）
@items = Item.order("created_at DESC").limit(4)

#WHY
ページの遷移は、サイトに必須であるため。