### PR TITLE
カテゴリー検索できるように実装

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -4,4 +4,9 @@ class CategoriesController < ApplicationController
     @categories = Category.select("name").where(ancestry: nil)
   end
 
+  def show
+    @item_categories = ItemCategory.select('item_id').where(category_id: params[:id])
+    @items = Item.where(id: @item_categories)
+  end
+
 end

--- a/app/views/categories/_index.html.haml
+++ b/app/views/categories/_index.html.haml
@@ -12,7 +12,7 @@
           - categories = Category.first.children.first.children
           - categories.each do |category|
             .category
-              = link_to "#{category.name}"
+              = link_to "#{category.name}", category_path(category)
         .cat-box
           %h4
             アウター
@@ -20,7 +20,7 @@
           - categories = Category.first.children.second.children
           - categories.each do |category|
             .category
-              = link_to "#{category.name}"
+              = link_to "#{category.name}", category_path(category)
         .cat-box
           %h4
             ボトムス
@@ -28,7 +28,7 @@
           - categories = Category.first.children.third.children
           - categories.each do |category|
             .category
-              = link_to "#{category.name}"
+              = link_to "#{category.name}", category_path(category)
         .cat-box
           %h4
             靴
@@ -36,7 +36,7 @@
           - categories = Category.first.children.fourth.children
           - categories.each do |category|
             .category
-              = link_to "#{category.name}"
+              = link_to "#{category.name}", category_path(category)
         .cat-box
           %h4
             カバン
@@ -44,7 +44,7 @@
           - categories = Category.first.children.fifth.children
           - categories.each do |category|
             .category
-              = link_to "#{category.name}"
+              = link_to "#{category.name}", category_path(category)
         .cat-box
           %h4
             その他

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,1 +1,18 @@
-
+= render 'layouts/header_form'
+.main-contents
+  .items-box-container
+    .items-box-content
+      - @items.each do |item_category|
+        .items-box
+          = link_to item_path(item_category) do
+            %figure.items-box-photo
+              = image_tag item_category.image.url
+            .items-box-body
+              .items-box-namefont
+                = item_category.name
+            .items-box-price
+              .items-box-price-font
+                = "¥" + item_category.price
+                %p.items-box-tax
+= render 'layouts/sell_btn'
+= render 'layouts/footer'


### PR DESCRIPTION
# what
- 出品時に登録したカテゴリーでの検索を実装
# how
- categories_controllerにshow actionを追加,
中間テーブルを経由して同じcategory_idを持つ商品をitems tableから拾ってこられるようにする
- トップページから開けるモーダルにリンクを設定, そこからカテゴリーのshowのviewへ遷移しカテゴリー検索で一覧表示できるようにした