### PR TITLE
#出品ページ 出品画像プレビュー表示

### DIFF
--- a/app/assets/javascripts/new.js
+++ b/app/assets/javascripts/new.js
@@ -1,0 +1,26 @@
+$(document).on('turbolinks:load', function() {
+
+    $(function() {
+     $('.hidden').change(function(e){
+        //ファイルオブジェクトを取得する
+        var file = e.target.files[0];
+        var reader = new FileReader();
+
+        //画像でない場合は処理終了
+        if(file.type.indexOf("image") < 0){
+          alert("画像ファイルを指定してください。");
+          return false;
+        }
+
+        //アップロードした画像を設定する
+        reader.onload = (function(file){
+          return function(e){
+            $(".image").attr("src", e.target.result);
+            $(".image").attr("title", file.name);
+          };
+        })(file);
+        reader.readAsDataURL(file);
+
+    });
+  });
+});

--- a/app/assets/stylesheets/modules/_new.scss
+++ b/app/assets/stylesheets/modules/_new.scss
@@ -69,15 +69,15 @@ select{
 
         .file-field{
           width: 620px;
-          height: 184px;
+          height: 100px;
           background-color: $light_gray;
           margin-top: 20px;
           border: 1px dashed #d8d8d8;
           text-align: center;
-          line-height: 184px;
+          line-height: 104px;
           position:relative;
           .hidden{
-            height:184px;
+            height:100px;
             width:620px;
             position:absolute;
             right:0;

--- a/app/assets/stylesheets/modules/_new.scss
+++ b/app/assets/stylesheets/modules/_new.scss
@@ -10,6 +10,7 @@
             background-color: $mercari_red;
             border-radius: 2px;
             padding: 2px 4px;
+            margin-bottom: 5px;
             display: inline-block;
           }
 
@@ -74,6 +75,15 @@ select{
           border: 1px dashed #d8d8d8;
           text-align: center;
           line-height: 184px;
+          position:relative;
+          .hidden{
+            height:184px;
+            width:620px;
+            position:absolute;
+            right:0;
+            left:0;
+            opacity: 0;
+          }
         }
       }
       .sell-item-description{

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -13,10 +13,11 @@
               出品画像
             %span.form-require
               必須
+            .sell-upload-image
+              = image_tag @item.image.url, height:"160", width:"160", class: 'image'
             .file-field
               クリックしてファイルをアップロード
-            = f.label class: 'form__mask__image' do
-              = fa_icon 'picture-o', class: 'icon'
+              / = f.label class: 'form__mask__image' do
               = f.file_field :image, class: 'hidden'
             - if @item.errors.any?
               %ul.has-error-text

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -13,10 +13,11 @@
               出品画像
             %span.form-require
               必須
+            .sell-upload-image
+              = image_tag "", height:"160", width:"160",class: 'image',alt:"ここに画像が表示されます"
             .file-field
               クリックしてファイルをアップロード
-            = f.label class: 'form__mask__image' do
-              = fa_icon 'picture-o', class: 'icon'
+              / = f.label class: 'form__mask__image' do
               = f.file_field :image, class: 'hidden'
             - if @item.errors.any?
               %ul.has-error-text


### PR DESCRIPTION
#WHAT
・出品ページにて、画像をアップロードした際、プレビューを表示させる。
　New.js …画像表示させる動きのJSファイル追加。

・表示する画像の大きさ、場所を設定する。
　= image_tag "", height:"160", width:"160",class: 'image',alt:"ここに画像が表示されます”

#WHY
プレビュー表示される事で、自分が選択した画像が一目で分かる。