### PR TITLE
#トップページ商品一覧レイアウト修正

### DIFF
--- a/app/assets/stylesheets/modules/_display-list.scss
+++ b/app/assets/stylesheets/modules/_display-list.scss
@@ -3,7 +3,7 @@
 }
 .items-box{
   width:213px;
-  margin:0 0 0 20px;
+  margin:0 0 20px 20px;
   background-color: $white;
   display:inline-block;
   figure{
@@ -14,7 +14,7 @@
   text-decoration: none;
 }
 .items-box-content{
-  margin-left:230px;
+  margin:0 auto;
 }
 .items-box-photo{
   margin: 0 ;


### PR DESCRIPTION
#WHAT
・商品一覧ページにて、各商品のレイアウトが中央になるように修正した。

display-list.scss
.items-box-content{
  margin:0 auto;
}